### PR TITLE
[winrt support] Changes to update some of the Windows APIs to help support the Windows Runtime

### DIFF
--- a/include/boost/detail/winapi/system.hpp
+++ b/include/boost/detail/winapi/system.hpp
@@ -1,7 +1,7 @@
 //  system.hpp  --------------------------------------------------------------//
 
 //  Copyright 2010 Vicente J. Botet Escriba
-//  Copyright (c) Microsoft Corporation
+//  Copyright (c) Microsoft Corporation 2014
 
 //  Distributed under the Boost Software License, Version 1.0.
 //  See http://www.boost.org/LICENSE_1_0.txt

--- a/include/boost/detail/winapi/time.hpp
+++ b/include/boost/detail/winapi/time.hpp
@@ -1,7 +1,7 @@
 //  time.hpp  --------------------------------------------------------------//
 
 //  Copyright 2010 Vicente J. Botet Escriba
-//  Copyright (c) Microsoft Corporation
+//  Copyright (c) Microsoft Corporation 2014
 
 //  Distributed under the Boost Software License, Version 1.0.
 //  See http://www.boost.org/LICENSE_1_0.txt
@@ -33,13 +33,13 @@ namespace winapi {
     #ifdef BOOST_HAS_GETSYSTEMTIMEASFILETIME  // Windows CE does not define GetSystemTimeAsFileTime
     using ::GetSystemTimeAsFileTime;
     #endif
-    #ifndef BOOST_WINDOWS_RUNTIME
+    #if BOOST_PLAT_WINDOWS_DESKTOP
     using ::FileTimeToLocalFileTime;
     #endif
     using ::GetSystemTime;
     using ::SystemTimeToFileTime;
     
-    #ifndef BOOST_WINDOWS_RUNTIME
+    #if BOOST_PLAT_WINDOWS_DESKTOP
     using ::GetTickCount;
     #endif
     #if BOOST_USE_WINAPI_VERSION >= BOOST_WINAPI_VERSION_WIN6
@@ -77,7 +77,7 @@ extern "C" {
     __declspec(dllimport) int WINAPI
         SystemTimeToFileTime(const SYSTEMTIME_* lpSystemTime,
                 FILETIME_* lpFileTime);
-    #ifndef BOOST_WINDOWS_RUNTIME
+    #if BOOST_PLAT_WINDOWS_DESKTOP
     __declspec(dllimport) DWORD_ WINAPI
         GetTickCount();
     #endif


### PR DESCRIPTION
These changes update some of the Windows APIs to newer versions when targeting later versions of Windows (for example GetSystemInfo/GetNativeSystemInfo). Some APIs that aren't available in the Windows Runtime are excluded unless targeting Windows desktop.
