### PR TITLE
Merge type_traits changes in develop

### DIFF
--- a/include/boost/detail/is_incrementable.hpp
+++ b/include/boost/detail/is_incrementable.hpp
@@ -10,7 +10,7 @@
 # include <boost/mpl/bool.hpp>
 # include <boost/detail/workaround.hpp>
 
-namespace boost { namespace detail { 
+namespace boost { namespace detail {
 
 // is_incrementable<T> metafunction
 //
@@ -24,7 +24,7 @@ namespace is_incrementable_
   // a type returned from operator++ when no increment is found in the
   // type's own namespace
   struct tag {};
-  
+
   // any soaks up implicit conversions and makes the following
   // operator++ less-preferred than any other such operator that
   // might be found via ADL.
@@ -32,7 +32,7 @@ namespace is_incrementable_
 
   // This is a last-resort operator++ for when none other is found
 # if BOOST_WORKAROUND(__GNUC__, == 4) && __GNUC_MINOR__ == 0 && __GNUC_PATCHLEVEL__ == 2
-  
+
 }
 
 namespace is_incrementable_2
@@ -44,33 +44,33 @@ using namespace is_incrementable_2;
 
 namespace is_incrementable_
 {
-  
+
 # else
-  
+
   tag operator++(any const&);
   tag operator++(any const&,int);
-  
-# endif 
+
+# endif
 
 # if BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3202)) 
 #  define BOOST_comma(a,b) (a)
-# else 
+# else
   // In case an operator++ is found that returns void, we'll use ++x,0
-  tag operator,(tag,int);  
+  tag operator,(tag,int);
 #  define BOOST_comma(a,b) (a,b)
-# endif 
+# endif
 
 # if defined(BOOST_MSVC)
 #  pragma warning(push)
 #  pragma warning(disable:4913) // Warning about operator,
-# endif 
+# endif
 
   // two check overloads help us identify which operator++ was picked
   char (& check_(tag) )[2];
-  
+
   template <class T>
   char check_(T const&);
-  
+
 
   template <class T>
   struct impl
@@ -96,23 +96,23 @@ namespace is_incrementable_
 
 # if defined(BOOST_MSVC)
 #  pragma warning(pop)
-# endif 
+# endif
 
 }
 
 # undef BOOST_comma
 
-template<typename T> 
-struct is_incrementable 
-: public ::boost::integral_constant<bool,::boost::detail::is_incrementable_::impl<T>::value>
-{ 
+template<typename T>
+struct is_incrementable :
+    public boost::integral_constant<bool, boost::detail::is_incrementable_::impl<T>::value>
+{
     BOOST_MPL_AUX_LAMBDA_SUPPORT(1,is_incrementable,(T))
 };
 
-template<typename T> 
-struct is_postfix_incrementable 
-: public ::boost::integral_constant<bool,::boost::detail::is_incrementable_::postfix_impl<T>::value>
-{ 
+template<typename T>
+struct is_postfix_incrementable :
+    public boost::integral_constant<bool, boost::detail::is_incrementable_::postfix_impl<T>::value>
+{
     BOOST_MPL_AUX_LAMBDA_SUPPORT(1,is_postfix_incrementable,(T))
 };
 


### PR DESCRIPTION
Now that the new version of type_traits is in master, we could use these changes in master too - otherwise you get hit by a small blizzard of warnings.