### PR TITLE
Most members of std::allocate are deprecated in C++17

### DIFF
--- a/include/boost/detail/allocator_utilities.hpp
+++ b/include/boost/detail/allocator_utilities.hpp
@@ -121,8 +121,13 @@ struct rebinder
   template<typename Type>
   struct result
   {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
       typedef typename Allocator::BOOST_NESTED_TEMPLATE 
           rebind<Type>::other other;
+#else
+      typedef typename std::allocator_traits<Allocator>::BOOST_NESTED_TEMPLATE 
+          rebind_alloc<Type> other;
+#endif
   };
 };
 


### PR DESCRIPTION
Replace them by their cousins from std::allocator_traits.

Signed-off-by: Daniela Engert <dani@ngrt.de>