### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/detail/catch_exceptions.hpp
+++ b/include/boost/detail/catch_exceptions.hpp
@@ -26,7 +26,7 @@
 #include <boost/cstdlib.hpp>  // for exit codes
 #include <ostream>         // for ostream
 
-# if defined(__BORLANDC__) && (__BORLANDC__ <= 0x0551)
+# if defined(BOOST_BORLANDC) && (BOOST_BORLANDC <= 0x0551)
 #   define BOOST_BUILT_IN_EXCEPTIONS_MISSING_WHAT 
 # endif
 

--- a/include/boost/detail/catch_exceptions.hpp
+++ b/include/boost/detail/catch_exceptions.hpp
@@ -26,7 +26,7 @@
 #include <boost/cstdlib.hpp>  // for exit codes
 #include <ostream>         // for ostream
 
-# if defined(BOOST_BORLANDC) && (BOOST_BORLANDC <= 0x0551)
+# if defined(__BORLANDC__) && !defined(__clang__) && (__BORLANDC__ <= 0x0551)
 #   define BOOST_BUILT_IN_EXCEPTIONS_MISSING_WHAT 
 # endif
 

--- a/include/boost/detail/catch_exceptions.hpp
+++ b/include/boost/detail/catch_exceptions.hpp
@@ -18,6 +18,7 @@
 
 //  header dependencies are deliberately restricted to the standard library
 //  to reduce coupling to other boost libraries.
+#include <boost/config.hpp>
 #include <string>             // for string
 #include <new>                // for bad_alloc
 #include <typeinfo>           // for bad_cast, bad_typeid
@@ -26,7 +27,7 @@
 #include <boost/cstdlib.hpp>  // for exit codes
 #include <ostream>         // for ostream
 
-# if defined(__BORLANDC__) && !defined(__clang__) && (__BORLANDC__ <= 0x0551)
+# if defined(BOOST_BORLANDC) && (__BORLANDC__ <= 0x0551)
 #   define BOOST_BUILT_IN_EXCEPTIONS_MISSING_WHAT 
 # endif
 

--- a/include/boost/detail/named_template_params.hpp
+++ b/include/boost/detail/named_template_params.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/type_traits/conversion_traits.hpp>
 #include <boost/type_traits/composite_traits.hpp> // for is_reference
-#if defined(__BORLANDC__)
+#if defined(BOOST_BORLANDC)
 #include <boost/type_traits/ice.hpp>
 #endif
 
@@ -57,7 +57,7 @@ namespace boost {
       };
     };
 
-#if defined(__BORLANDC__)
+#if defined(BOOST_BORLANDC)
     template <class UseDefault>
     struct choose_arg_or_default { typedef choose_arg type; };
     template <>
@@ -75,7 +75,7 @@ namespace boost {
     
     template <class Arg, class DefaultGen, class Base, class Traits>
     class resolve_default {
-#if defined(__BORLANDC__)
+#if defined(BOOST_BORLANDC)
       typedef typename choose_arg_or_default<typename is_default<Arg>::type>::type Selector;
 #else
       // This usually works for Borland, but I'm seeing weird errors in

--- a/include/boost/detail/named_template_params.hpp
+++ b/include/boost/detail/named_template_params.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_DETAIL_NAMED_TEMPLATE_PARAMS_HPP
 #define BOOST_DETAIL_NAMED_TEMPLATE_PARAMS_HPP
 
+#include <boost/config.hpp>
 #include <boost/type_traits/conversion_traits.hpp>
 #include <boost/type_traits/composite_traits.hpp> // for is_reference
 #if defined(BOOST_BORLANDC)


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.