### PR TITLE
Change encoding to UTF-8 for doc/html/minimal.css

### DIFF
--- a/doc/html/minimal.css
+++ b/doc/html/minimal.css
@@ -1,6 +1,6 @@
 /*
 
-  © Copyright Beman Dawes, 2007
+  Â© Copyright Beman Dawes, 2007
 
   Distributed under the Boost Software License, Version 1.0.
   See www.boost.org/LICENSE_1_0.txt


### PR DESCRIPTION
CSS files should be UTF-8: https://www.w3.org/International/questions/qa-css-charset

https://github.com/boostorg/filesystem/commit/9df2bfab58aadf35b4e01f2fd6252e1521409779#diff-36873c6a5a238ba4df45a47d97d80ead5ed664b3cb7e5a8fbe918020cc6889a4 replaced another ISO-8859-1 copyright symbol with `(c)`, which would also be an option here. I just want to get rid of the ISO-8859-1 character in a file that doesn't specify its `@charset`, because it causes warnings for distro packagers.

See also https://github.com/boostorg/boost/pull/618 and https://github.com/boostorg/multi_index/pull/55